### PR TITLE
Fix categories user id foreign key constraint

### DIFF
--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -403,16 +403,8 @@ CREATE TRIGGER generate_travel_days_trigger
 -- 10. 기본 데이터 삽입
 -- ===============================================
 
--- 기본 plan_type 열거형 데이터 (참고용)
-INSERT INTO public.categories (id, user_id, name, color, icon, is_default) 
-VALUES 
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '관광', '#3b82f6', 'camera', true),
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '음식', '#10b981', 'utensils', true),
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '숙박', '#8b5cf6', 'bed', true),
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '교통', '#f59e0b', 'car', true),
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '쇼핑', '#ef4444', 'shopping-bag', true),
-  (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '엔터테인먼트', '#ec4899', 'music', true)
-ON CONFLICT DO NOTHING;
+-- Note: Default categories will be created automatically when users sign up
+-- through the application logic, not during migration to avoid foreign key issues
 
 -- ===============================================
 -- 마이그레이션 완료


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove hardcoded default category insertion from migration to fix foreign key constraint violation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous migration attempted to insert default categories with a non-existent user ID, leading to a foreign key error. This change ensures that default categories are created through application logic when a user signs up, aligning with best practices and preventing migration failures.

---

[Open in Web](https://cursor.com/agents?id=bc-b71362cd-ab52-4b19-87ef-50d4163cf4dc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b71362cd-ab52-4b19-87ef-50d4163cf4dc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)