### PR TITLE
Update upload artifact action to v4

### DIFF
--- a/.github/workflows/deploy-nextjs.yml
+++ b/.github/workflows/deploy-nextjs.yml
@@ -52,7 +52,7 @@ jobs:
         cname: travel.moonwave.kr
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-files
         path: out/


### PR DESCRIPTION
Update `actions/upload-artifact` to `v4` to resolve the deprecation error.

---

[Open in Web](https://cursor.com/agents?id=bc-ddb64c00-2c6e-451e-ba41-900f1f6ae46d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ddb64c00-2c6e-451e-ba41-900f1f6ae46d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)