### PR TITLE
Publish assets to gh-pages branch

### DIFF
--- a/.github/workflows/deploy-nextjs.yml
+++ b/.github/workflows/deploy-nextjs.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -43,13 +55,22 @@ jobs:
         GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
         NEXT_PUBLIC_SITE_URL: https://travel.moonwave.kr
     
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
       if: github.ref == 'refs/heads/main'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./out
-        cname: travel.moonwave.kr
+        static_site_generator: next
+        
+    - name: Upload to GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        path: ./out
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+      if: github.ref == 'refs/heads/main'
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Add any Next.js configuration here
+  output: 'export',
+  trailingSlash: true,
+  images: {
+    unoptimized: true
+  },
+  // Configure for GitHub Pages deployment
+  basePath: process.env.NODE_ENV === 'production' ? '' : '',
+  assetPrefix: process.env.NODE_ENV === 'production' ? '' : '',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Migrate GitHub Pages deployment to official actions and configure Next.js for static export to resolve deployment permission errors.

---

[Open in Web](https://cursor.com/agents?id=bc-7659a5ed-0466-4b48-95e9-70fbc8bd5239) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7659a5ed-0466-4b48-95e9-70fbc8bd5239) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)