### PR TITLE
Check for type errors in ImageUpload

### DIFF
--- a/components/features/upload/ImageUpload.tsx
+++ b/components/features/upload/ImageUpload.tsx
@@ -72,7 +72,7 @@ export function ImageUpload({
     return new Promise((resolve) => {
       const canvas = document.createElement('canvas')
       const ctx = canvas.getContext('2d')!
-      const img = new Image()
+      const img = new window.Image()
 
       img.onload = () => {
         // Calculate new dimensions


### PR DESCRIPTION
Fix TypeScript error in ImageUpload by explicitly using native `window.Image` constructor.

---

[Open in Web](https://cursor.com/agents?id=bc-37bf1bbc-a954-46d3-8268-2372ef5a9e77) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-37bf1bbc-a954-46d3-8268-2372ef5a9e77) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)