### PR TITLE
Enable dependency review for repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,46 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        uses: oke-py/npm-audit-action@v3
+        with:
+          audit_level: moderate
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_issues: true
+          create_pr_comments: true
+          issue_labels: vulnerability,security
+          dedupe_issues: true
+
+  npm-audit:
+    name: NPM Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: |
+          npm audit --audit-level=moderate
+          echo "NPM audit completed successfully!"
 
   lighthouse:
     name: Lighthouse CI


### PR DESCRIPTION
Replace GitHub Dependency Review with `npm audit` actions to enable dependency scanning without GitHub Advanced Security.

The `actions/dependency-review-action@v4` failed due to the repository not having GitHub Advanced Security enabled. This PR introduces two `npm audit` based jobs: one using `oke-py/npm-audit-action@v3` for enhanced features (issue/PR comment creation) and another basic `npm audit` job, both providing vulnerability scanning without requiring Advanced Security.

---

[Open in Web](https://cursor.com/agents?id=bc-5e911ebd-3f4e-47ed-8d0b-ba307f62ead9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5e911ebd-3f4e-47ed-8d0b-ba307f62ead9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)