### PR TITLE
Update deployment status failed

### DIFF
--- a/.github/workflows/vercel-deployment.yml
+++ b/.github/workflows/vercel-deployment.yml
@@ -75,6 +75,49 @@ jobs:
           url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "preview_url=$url" >> $GITHUB_OUTPUT
 
+      - name: Create preview deployment
+        uses: actions/github-script@v7
+        id: create_preview_deployment
+        with:
+          script: |
+            try {
+              const deployment = await github.rest.repos.createDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+                environment: 'preview',
+                description: 'Preview deployment via Vercel',
+                auto_merge: false,
+                required_contexts: []
+              });
+              console.log('✅ Preview deployment created with ID:', deployment.data.id);
+              return deployment.data.id;
+            } catch (error) {
+              console.error('❌ Failed to create preview deployment:', error.message);
+              core.setFailed(`Failed to create preview deployment: ${error.message}`);
+              return null;
+            }
+
+      - name: Update preview deployment status
+        uses: actions/github-script@v7
+        if: steps.create_preview_deployment.outputs.result
+        with:
+          script: |
+            try {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: ${{ steps.create_preview_deployment.outputs.result }},
+                state: 'success',
+                environment_url: '${{ steps.deploy.outputs.preview_url }}',
+                description: 'Preview deployment successful'
+              });
+              console.log('✅ Preview deployment status updated successfully');
+            } catch (error) {
+              console.error('❌ Failed to update preview deployment status:', error.message);
+              core.setFailed(`Failed to update preview deployment status: ${error.message}`);
+            }
+
       - name: Comment PR with Preview URL
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
@@ -113,18 +156,48 @@ jobs:
           url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
           echo "production_url=$url" >> $GITHUB_OUTPUT
 
-      - name: Create deployment status
+      - name: Create deployment
         uses: actions/github-script@v7
+        id: create_deployment
         with:
           script: |
-            github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: context.payload.deployment?.id || Date.now(),
-              state: 'success',
-              environment_url: '${{ steps.deploy.outputs.production_url }}',
-              description: 'Production deployment successful'
-            })
+            try {
+              const deployment = await github.rest.repos.createDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+                environment: 'production',
+                description: 'Production deployment via Vercel',
+                auto_merge: false,
+                required_contexts: []
+              });
+              console.log('✅ Production deployment created with ID:', deployment.data.id);
+              return deployment.data.id;
+            } catch (error) {
+              console.error('❌ Failed to create deployment:', error.message);
+              core.setFailed(`Failed to create deployment: ${error.message}`);
+              return null;
+            }
+
+      - name: Update deployment status
+        uses: actions/github-script@v7
+        if: steps.create_deployment.outputs.result
+        with:
+          script: |
+            try {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: ${{ steps.create_deployment.outputs.result }},
+                state: 'success',
+                environment_url: '${{ steps.deploy.outputs.production_url }}',
+                description: 'Production deployment successful'
+              });
+              console.log('✅ Deployment status updated successfully');
+            } catch (error) {
+              console.error('❌ Failed to update deployment status:', error.message);
+              core.setFailed(`Failed to update deployment status: ${error.message}`);
+            }
 
   # 보안 검사
   security-check:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes 404 error in Vercel deployment status updates by correctly creating and referencing GitHub deployment IDs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous workflow attempted to update a deployment status using `context.payload.deployment?.id` (which was often undefined) or `Date.now()` as a fallback. This resulted in a `404 Not Found` error because the generated ID did not correspond to an actual GitHub deployment. This PR introduces explicit steps to first create a GitHub deployment record and then use its returned ID to update the status, ensuring valid API calls. It also adds robust error handling and applies the same logic to preview deployments for consistency.

---

[Open in Web](https://cursor.com/agents?id=bc-1e48830e-ab38-4d02-9ec4-5934d6286397) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1e48830e-ab38-4d02-9ec4-5934d6286397) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)