### PR TITLE
Add npm audit security scan to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,26 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
 
+  dependency-audit:
+    name: npm Audit Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --audit-level=moderate
+
   lighthouse:
     name: Lighthouse CI
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add an `npm audit` job to `ci.yml` to enable free dependency vulnerability detection.

---

[Open in Web](https://cursor.com/agents?id=bc-be0afdaf-0ab1-4456-918e-4ae9c0c34eea) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-be0afdaf-0ab1-4456-918e-4ae9c0c34eea) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)