### PR TITLE
Fix ignored css import rule

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,9 @@
+/* Pretendard 폰트 로드 */
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Pretendard 폰트 로드 */
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 
 @layer base {
   :root {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move `@import` rule to the top of `app/globals.css` to resolve CSS standard warning.

---

[Open in Web](https://cursor.com/agents?id=bc-83b74467-c19e-4d5e-bef0-fe91e1f766d6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-83b74467-c19e-4d5e-bef0-fe91e1f766d6) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)