### PR TITLE
Change button layout to horizontal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -187,17 +187,17 @@ export default function HomePage() {
 
           <div className="flex flex-col justify-center gap-4 sm:flex-row">
             <Button asChild size="lg">
-              <Link href={user ? '/travels/new' : '/signin'}>
-                <Plus className="mr-2 h-5 w-5" />
-                {user ? '새 여행 만들기' : '지금 시작하기'}
+              <Link href={user ? '/travels/new' : '/signin'} className="flex items-center gap-2">
+                <Plus className="h-5 w-5" />
+                <span>{user ? '새 여행 만들기' : '지금 시작하기'}</span>
               </Link>
             </Button>
 
             {user && (
               <Button asChild variant="outline" size="lg">
-                <Link href="/map">
-                  <MapPin className="mr-2 h-5 w-5" />
-                  지도에서 보기
+                <Link href="/map" className="flex items-center gap-2">
+                  <MapPin className="h-5 w-5" />
+                  <span>지도에서 보기</span>
                 </Link>
               </Button>
             )}

--- a/app/travels/page.tsx
+++ b/app/travels/page.tsx
@@ -127,8 +127,9 @@ export default function TravelsPage() {
 
             <div className="flex-shrink-0 @lg/header:ml-6">
               <Button asChild size="lg" className="w-full @lg/header:w-auto">
-                <Link href="/travels/new">
-                  <Plus className="mr-2 h-5 w-5" />새 여행 만들기
+                <Link href="/travels/new" className="flex items-center gap-2">
+                  <Plus className="h-5 w-5" />
+                  <span>새 여행 만들기</span>
                 </Link>
               </Button>
             </div>

--- a/components/features/travel/EmptyTravelState.tsx
+++ b/components/features/travel/EmptyTravelState.tsx
@@ -41,15 +41,16 @@ export function EmptyTravelState() {
         {/* 액션 버튼 */}
         <div className="flex flex-col justify-center gap-3 sm:flex-row">
           <Button asChild size="lg">
-            <Link href="/travels/new">
-              <Plus className="mr-2 h-5 w-5" />새 여행 만들기
+            <Link href="/travels/new" className="flex items-center gap-2">
+              <Plus className="h-5 w-5" />
+              <span>새 여행 만들기</span>
             </Link>
           </Button>
 
           <Button asChild variant="outline" size="lg">
-            <Link href="/examples">
-              <Compass className="mr-2 h-5 w-5" />
-              예시 여행 보기
+            <Link href="/examples" className="flex items-center gap-2">
+              <Compass className="h-5 w-5" />
+              <span>예시 여행 보기</span>
             </Link>
           </Button>
         </div>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -12,7 +12,8 @@ const buttonVariants = cva(
     'transition-all duration-200',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
     'disabled:pointer-events-none disabled:opacity-50',
-    'active:scale-[0.98]'
+    'active:scale-[0.98]',
+    'flex-row gap-2'
   ),
   {
     variants: {
@@ -87,9 +88,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {loading ? (
-          <>
+          <div className="flex items-center gap-2">
             <svg
-              className="-ml-1 mr-2 h-4 w-4 animate-spin"
+              className="h-4 w-4 animate-spin"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -112,11 +113,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <span className="tracking-korean-normal break-keep-ko">
               처리 중...
             </span>
-          </>
+          </div>
         ) : (
-          <span className="tracking-korean-normal break-keep-ko">
+          <div className="flex items-center gap-2">
             {children}
-          </span>
+          </div>
         )}
       </Comp>
     );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change button icon and text layout from vertical to horizontal as requested.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Although the `Button` component had `inline-flex`, when `asChild` was used with a `Link` component, the `Link` itself needed explicit flex styling to arrange its internal icon and text horizontally. This PR ensures all such buttons correctly display icons and text side-by-side with appropriate spacing by applying `flex items-center gap-2` to the `Link` and wrapping text in `<span>`.

---

[Open in Web](https://cursor.com/agents?id=bc-cf3d4355-a741-49d2-a774-3f8d3e6ea155) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf3d4355-a741-49d2-a774-3f8d3e6ea155) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)