### PR TITLE
여행 관리 상단 아이콘만 표시

### DIFF
--- a/components/features/travel/TravelDetailView.tsx
+++ b/components/features/travel/TravelDetailView.tsx
@@ -99,29 +99,29 @@ export default function TravelDetailView({ travelId }: TravelDetailViewProps) {
           <Link href={`/map?travelId=${travelId}`}>
             <Button
               variant="default"
-              size="default"
-              className="flex items-center gap-2"
+              size="icon"
+              className="h-10 w-10"
+              title="지도 보기"
             >
               <MapPin className="h-4 w-4" />
-              지도 보기
             </Button>
           </Link>
           <Button
             variant="outline"
-            size="default"
-            className="flex items-center gap-2"
+            size="icon"
+            className="h-10 w-10"
+            title="공유"
           >
             <Share2 className="h-4 w-4" />
-            공유
           </Button>
           <Link href={`/travels/${travelId}/edit`}>
             <Button
               variant="outline"
-              size="default"
-              className="flex items-center gap-2"
+              size="icon"
+              className="h-10 w-10"
+              title="수정"
             >
               <Edit className="h-4 w-4" />
-              수정
             </Button>
           </Link>
         </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove text from "지도보기", "공유", "수정" buttons in travel management to display only icons.

---

[Open in Web](https://cursor.com/agents?id=bc-684c8d5a-ff95-437b-b310-fe43b8d43e98) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-684c8d5a-ff95-437b-b310-fe43b8d43e98) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)