### PR TITLE
Check code formatting with prettier

### DIFF
--- a/components/ui/backgrounds.tsx
+++ b/components/ui/backgrounds.tsx
@@ -297,5 +297,3 @@ export const CUSTOM_STYLES = `
   -webkit-text-fill-color: transparent;
 }
 `;
-
-

--- a/next.config.js
+++ b/next.config.js
@@ -30,10 +30,10 @@ const nextConfig = {
     const cspDirectives = [
       "default-src 'self'",
       `script-src 'self' 'unsafe-inline' ${isDev ? "'unsafe-eval'" : ''} https://maps.googleapis.com https://maps.gstatic.com`,
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",  // ✅ CDN 추가
-      "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net",  // ✅ 폰트 CDN 추가
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net", // ✅ CDN 추가
+      "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net", // ✅ 폰트 CDN 추가
       "img-src 'self' data: https: blob:",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",  // ✅ WebSocket 추가
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co", // ✅ WebSocket 추가
       "object-src 'none'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
Fix Prettier formatting issues to resolve `npm run format:check` errors.

---

[Open in Web](https://cursor.com/agents?id=bc-7cef7062-48e4-4a5a-bcf4-3cd2aa28c2dd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7cef7062-48e4-4a5a-bcf4-3cd2aa28c2dd) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)