### PR TITLE
Run project linting checks

### DIFF
--- a/components/features/travel/__tests__/EmptyTravelState.test.tsx
+++ b/components/features/travel/__tests__/EmptyTravelState.test.tsx
@@ -12,7 +12,7 @@ describe('EmptyTravelState', () => {
   });
 
   it('Pretendard 폰트 클래스가 적용되어야 함', () => {
-    const { container } = render(<EmptyTravelState />);
+    render(<EmptyTravelState />);
     
     const titleElement = screen.getByText('첫 번째 여행을 계획해보세요');
     expect(titleElement).toHaveClass('font-pretendard');

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -278,7 +278,7 @@ describe('utils', () => {
     it('SSR 환경에서 안전하게 작동해야 함', () => {
       // window 객체 제거
       const originalWindow = global.window;
-      delete (global as any).window;
+      delete (global as Record<string, unknown>).window;
 
       expect(safeLocalStorage.getItem('test-key')).toBeUndefined();
       expect(() => safeLocalStorage.setItem('test-key', 'value')).not.toThrow();

--- a/lib/utils/errorHandling.ts
+++ b/lib/utils/errorHandling.ts
@@ -84,7 +84,7 @@ const GENERAL_ERROR_MESSAGES: Record<string, string> = {
  * @returns 한글 에러 메시지
  */
 export const getKoreanErrorMessage = (
-  error: any,
+  error: unknown,
   context: ErrorContext = 'database'
 ): string => {
   const message = error?.message || error?.toString() || '';
@@ -157,7 +157,7 @@ export const getKoreanErrorMessage = (
  * @param operation - 수행 중이던 작업
  */
 export const logError = (
-  error: any,
+  error: unknown,
   context: string,
   operation?: string
 ): void => {
@@ -175,7 +175,7 @@ export const logError = (
  * @returns 에러 타입
  */
 export const classifyError = (
-  error: any
+  error: unknown
 ): 'network' | 'auth' | 'database' | 'validation' | 'unknown' => {
   const message = error?.message || error?.toString() || '';
 


### PR DESCRIPTION
Fix linting errors by removing unused variables and replacing `any` types with `unknown` or specific types.

---

[Open in Web](https://cursor.com/agents?id=bc-9d510658-faf5-439b-96ff-ffd55d83757f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9d510658-faf5-439b-96ff-ffd55d83757f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)