### PR TITLE
Run type check and fix errors

### DIFF
--- a/lib/utils/errorHandling.ts
+++ b/lib/utils/errorHandling.ts
@@ -87,7 +87,7 @@ export const getKoreanErrorMessage = (
   error: unknown,
   context: ErrorContext = 'database'
 ): string => {
-  const message = error?.message || error?.toString() || '';
+  const message = (error as any)?.message || (error as any)?.toString() || '';
 
   // 모든 에러 메시지 매핑을 하나로 합치기
   const allErrorMessages = {
@@ -177,7 +177,7 @@ export const logError = (
 export const classifyError = (
   error: unknown
 ): 'network' | 'auth' | 'database' | 'validation' | 'unknown' => {
-  const message = error?.message || error?.toString() || '';
+  const message = (error as any)?.message || (error as any)?.toString() || '';
 
   if (
     message.includes('network') ||


### PR DESCRIPTION
Fix TypeScript errors by casting `unknown` error types to `any` when accessing the `message` property.

---

[Open in Web](https://cursor.com/agents?id=bc-4b201727-422e-4f71-a4a3-b3b7035e0829) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4b201727-422e-4f71-a4a3-b3b7035e0829) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)